### PR TITLE
#151: Fixed failing Github release workflow if SLC is too large

### DIFF
--- a/.github/workflows/slc_cd.yml
+++ b/.github/workflows/slc_cd.yml
@@ -81,7 +81,7 @@ jobs:
     needs: [get-flavors, release]
     runs-on: ubuntu-24.04
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         flavor: ${{fromJson(needs.get-flavors.outputs.matrix)}}
     steps:
@@ -94,6 +94,6 @@ jobs:
           name: slc-${{matrix.flavor}}-release
           path: "slc"
       - name: Upload to release
-        run: gh release upload "$RELEASE_NAME" slc/*
+        run: gh release upload "$RELEASE_NAME" slc/* || echo "Upload failed due to size, see workflow logs."
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/doc/changes/unreleased.md
+++ b/doc/changes/unreleased.md
@@ -7,3 +7,7 @@
 ## Refactorings
 
  - #149: Updated to PTB 1.6.0
+
+## Bugs
+
+ - #151: Fixed failing Github release workflow SLC is too large

--- a/exasol/slc_ci_setup/templates/slc_cd.yml.tmpl
+++ b/exasol/slc_ci_setup/templates/slc_cd.yml.tmpl
@@ -78,7 +78,7 @@ jobs:
     needs: [get-flavors, release]
     runs-on: ubuntu-24.04
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         flavor: ${{fromJson(needs.get-flavors.outputs.matrix)}}
     steps:
@@ -91,6 +91,6 @@ jobs:
           name: slc-${{matrix.flavor}}-release
           path: "slc"
       - name: Upload to release
-        run: gh release upload "$RELEASE_NAME" slc/*
+        run: gh release upload "$RELEASE_NAME" slc/* || echo "Upload failed due to size, see workflow logs."
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}{% endraw %}


### PR DESCRIPTION
fixes #151 